### PR TITLE
New option: min_match_length

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ match results.
 
 ## max_buffer_lines (type: int)
 
-Te plugin will not work in buffers with more than `max_buffer_lines` lines for
+The plugin will not work in buffers with more than `max_buffer_lines` lines for
 performance reasons.
 
 _Default:_ 20000
@@ -118,6 +118,12 @@ _Default:_ 20000
 Do not show matches longer than `max_match_length`.
 
 _Default:_ 50
+
+## min_match_length (type: int)
+
+Do not show matches shorter than `min_match_length`.
+
+_Default:_ 1
 
 ## fuzzy_extra_arg
 

--- a/doc/cmp-fuzzy-buffer.txt
+++ b/doc/cmp-fuzzy-buffer.txt
@@ -154,6 +154,12 @@ Do not show matches longer than `max_match_length`.
 
 _Default:_ 50
 
+MIN_MATCH_LENGTH (TYPE: INT)   *cmp-fuzzy-buffer-min_match_length-(type:-int)*
+
+Do not show matches shorter than `min_match_length`.
+
+_Default:_ 1
+
 FUZZY_EXTRA_ARG                             *cmp-fuzzy-buffer-fuzzy_extra_arg*
 
 This has different meaning depending on the fuzzy matching library used. For

--- a/lua/cmp_fuzzy_buffer/init.lua
+++ b/lua/cmp_fuzzy_buffer/init.lua
@@ -73,12 +73,12 @@ source.regex = function(self, pattern)
   return self.regexes[pattern]
 end
 
-source.get_keyword_pattern = function()
+source.get_keyword_pattern = function(self, params)
+  params.option = vim.tbl_deep_extend('keep', params.option, defaults)
   if vim.api.nvim_get_mode().mode == 'c' then
-    return '.*'
+    return string.format([=[.\{%d,}]=], params.option.min_match_length)
   else
-    -- return [=[[^[:blank:]\[\]()=:'"\.,-{}]\+]=]
-    return [=[\k\+]=]
+    return string.format([=[\k\{%d,}]=], params.option.min_match_length)
   end
 end
 
@@ -87,10 +87,6 @@ source.complete = function(self, params, callback)
   local is_cmd = (vim.api.nvim_get_mode().mode == 'c')
   -- in cmd mode we take all the line as a pattern
   local pattern = params.context.cursor_before_line:sub(params.offset)
-  if #pattern < params.option.min_match_length then
-    callback({ items = {}, isIncomplete = true })
-    return
-  end
 
   vim.schedule(function()
     local lines = {}


### PR DESCRIPTION
Add a new option `min_match_length`
If the input is shorter than min_match_length, do not send the match items. 
This will be helpful for the latency of large files.